### PR TITLE
Disallow interspersed options/non-options

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,8 @@ letters for flags. All but the last shorthand letter must be boolean flags.
 -abcn1234
 ```
 
-Flag parsing stops after the terminator "--". Unlike the flag package,
-flags can be interspersed with arguments anywhere on the command line
-before this terminator.
+Flag parsing stops at the first non-option argument or the terminator
+"--".
 
 Integer flags accept 1234, 0664, 0x1234 and may be negative.
 Boolean flags (in their long form) accept 1, 0, t, f, true, false,

--- a/example_test.go
+++ b/example_test.go
@@ -3,22 +3,20 @@
 // license that can be found in the LICENSE file.
 
 // These examples demonstrate more intricate uses of the flag package.
-package pflag_test
+package pflag
 
 import (
 	"errors"
 	"fmt"
 	"strings"
 	"time"
-
-	flag "github.com/ogier/pflag"
 )
 
 // Example 1: A single string flag called "species" with default value "gopher".
-var species = flag.String("species", "gopher", "the species we are studying")
+var species = String("species", "gopher", "the species we are studying")
 
 // Example 2: A flag with a shorthand letter.
-var gopherType = flag.StringP("gopher_type", "g", "pocket", "the variety of gopher")
+var gopherType = StringP("gopher_type", "g", "pocket", "the variety of gopher")
 
 // Example 3: A user-defined flag type, a slice of durations.
 type interval []time.Duration
@@ -60,7 +58,7 @@ var intervalFlag interval
 func init() {
 	// Tie the command-line flag to the intervalFlag variable and
 	// set a usage message.
-	flag.Var(&intervalFlag, "deltaT", "comma-separated list of intervals to use between events")
+	Var(&intervalFlag, "deltaT", "comma-separated list of intervals to use between events")
 }
 
 func Example() {

--- a/flag.go
+++ b/flag.go
@@ -78,9 +78,8 @@
 		-abcs "hello"
 		-abcn1234
 
-	Flag parsing stops after the terminator "--". Unlike the flag package,
-	flags can be interspersed with arguments anywhere on the command line
-	before this terminator.
+    Flag parsing stops at the first non-option argument or the terminator
+    "--".
 
 	Integer flags accept 1234, 0664, 0x1234 and may be negative.
 	Boolean flags (in their long form) accept 1, 0, t, f, true, false,
@@ -917,11 +916,11 @@ func (f *FlagSet) setFlag(flag *Flag, value string, origArg string) error {
 func (f *FlagSet) parseArgs(args []string) error {
 	for len(args) > 0 {
 		s := args[0]
-		args = args[1:]
 		if len(s) == 0 || s[0] != '-' || len(s) == 1 {
-			f.args = append(f.args, s)
-			continue
+			f.args = args[:]
+			return nil
 		}
+		args = args[1:]
 
 		if s[1] == '-' {
 			if len(s) == 2 { // "--" terminates the flags

--- a/flag_test.go
+++ b/flag_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package pflag_test
+package pflag
 
 import (
 	"bytes"
@@ -12,8 +12,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	. "github.com/ogier/pflag"
 )
 
 var (
@@ -190,10 +188,10 @@ func TestShorthand(t *testing.T) {
 	args := []string{
 		"-ab",
 		extra,
+		notaflag,
 		"-cs",
 		"hello",
 		"--",
-		notaflag,
 	}
 	if err := f.Parse(args); err != nil {
 		t.Fatal(err)
@@ -207,14 +205,14 @@ func TestShorthand(t *testing.T) {
 	if *boolbFlag != true {
 		t.Error("boolb flag should be true, is ", *boolbFlag)
 	}
-	if *boolcFlag != true {
-		t.Error("boolc flag should be true, is ", *boolcFlag)
+	if *boolcFlag != false {
+		t.Error("boolc flag should be false, is ", *boolcFlag)
 	}
-	if *stringFlag != "hello" {
-		t.Error("string flag should be `hello`, is ", *stringFlag)
+	if *stringFlag == "hello" {
+		t.Error("string flag should not be `hello`, is ", *stringFlag)
 	}
-	if len(f.Args()) != 2 {
-		t.Error("expected one argument, got", len(f.Args()))
+	if len(f.Args()) != 5 {
+		t.Error("expected 5 arguments, got", len(f.Args()))
 	} else if f.Args()[0] != extra {
 		t.Errorf("expected argument %q got %q", extra, f.Args()[0])
 	} else if f.Args()[1] != notaflag {


### PR DESCRIPTION
This is very useful in conjunction with FlagSets for supporting "commands" with differing sets of options.

eg.

```
cmd --loglevel=debug ls -la
cmd run --command=/bin/ls
```

Where the arguments to the `ls` and `run` commands are in different `FlagSet`s. Without this capability, `FlagSet`s are quite a bit less useful.

I personally prefer this as the default, but it may not be what you want. If that is the case I can modify the patch to optionally allow interspersed options via an alternate `Parse()` entry point.
