### PR TITLE
Shorthand only flags

### DIFF
--- a/bool.go
+++ b/bool.go
@@ -32,6 +32,11 @@ func (f *FlagSet) BoolVarP(p *bool, name, shorthand string, value bool, usage st
 	f.VarP(newBoolValue(value, p), name, shorthand, usage)
 }
 
+// Like BoolVar, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) BoolVarS(p *bool, shorthand string, value bool, usage string) {
+	f.VarP(newBoolValue(value, p), "", shorthand, usage)
+}
+
 // BoolVar defines a bool flag with specified name, default value, and usage string.
 // The argument p points to a bool variable in which to store the value of the flag.
 func BoolVar(p *bool, name string, value bool, usage string) {
@@ -41,6 +46,11 @@ func BoolVar(p *bool, name string, value bool, usage string) {
 // Like BoolVar, but accepts a shorthand letter that can be used after a single dash.
 func BoolVarP(p *bool, name, shorthand string, value bool, usage string) {
 	CommandLine.VarP(newBoolValue(value, p), name, shorthand, usage)
+}
+
+// Like BoolVar, but only accepts a shorthand letter that can be used after a single dash.
+func BoolVarS(p *bool, shorthand string, value bool, usage string) {
+	CommandLine.VarP(newBoolValue(value, p), "", shorthand, usage)
 }
 
 // Bool defines a bool flag with specified name, default value, and usage string.
@@ -58,6 +68,13 @@ func (f *FlagSet) BoolP(name, shorthand string, value bool, usage string) *bool 
 	return p
 }
 
+// Like Bool, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) BoolS(shorthand string, value bool, usage string) *bool {
+	p := new(bool)
+	f.BoolVarP(p, "", shorthand, value, usage)
+	return p
+}
+
 // Bool defines a bool flag with specified name, default value, and usage string.
 // The return value is the address of a bool variable that stores the value of the flag.
 func Bool(name string, value bool, usage string) *bool {
@@ -67,4 +84,9 @@ func Bool(name string, value bool, usage string) *bool {
 // Like Bool, but accepts a shorthand letter that can be used after a single dash.
 func BoolP(name, shorthand string, value bool, usage string) *bool {
 	return CommandLine.BoolP(name, shorthand, value, usage)
+}
+
+// Like Bool, but only accepts a shorthand letter that can be used after a single dash.
+func BoolS(shorthand string, value bool, usage string) *bool {
+	return CommandLine.BoolP("", shorthand, value, usage)
 }

--- a/duration.go
+++ b/duration.go
@@ -36,6 +36,11 @@ func (f *FlagSet) DurationVarP(p *time.Duration, name, shorthand string, value t
 	f.VarP(newDurationValue(value, p), name, shorthand, usage)
 }
 
+// Like DurationVar, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) DurationVarS(p *time.Duration, shorthand string, value time.Duration, usage string) {
+	f.VarP(newDurationValue(value, p), "", shorthand, usage)
+}
+
 // DurationVar defines a time.Duration flag with specified name, default value, and usage string.
 // The argument p points to a time.Duration variable in which to store the value of the flag.
 func DurationVar(p *time.Duration, name string, value time.Duration, usage string) {
@@ -45,6 +50,11 @@ func DurationVar(p *time.Duration, name string, value time.Duration, usage strin
 // Like DurationVar, but accepts a shorthand letter that can be used after a single dash.
 func DurationVarP(p *time.Duration, name, shorthand string, value time.Duration, usage string) {
 	CommandLine.VarP(newDurationValue(value, p), name, shorthand, usage)
+}
+
+// Like DurationVar, but only accepts a shorthand letter that can be used after a single dash.
+func DurationVarS(p *time.Duration, shorthand string, value time.Duration, usage string) {
+	CommandLine.VarP(newDurationValue(value, p), "", shorthand, usage)
 }
 
 // Duration defines a time.Duration flag with specified name, default value, and usage string.
@@ -62,6 +72,13 @@ func (f *FlagSet) DurationP(name, shorthand string, value time.Duration, usage s
 	return p
 }
 
+// Like Duration, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) DurationS(shorthand string, value time.Duration, usage string) *time.Duration {
+	p := new(time.Duration)
+	f.DurationVarP(p, "", shorthand, value, usage)
+	return p
+}
+
 // Duration defines a time.Duration flag with specified name, default value, and usage string.
 // The return value is the address of a time.Duration variable that stores the value of the flag.
 func Duration(name string, value time.Duration, usage string) *time.Duration {
@@ -71,4 +88,9 @@ func Duration(name string, value time.Duration, usage string) *time.Duration {
 // Like Duration, but accepts a shorthand letter that can be used after a single dash.
 func DurationP(name, shorthand string, value time.Duration, usage string) *time.Duration {
 	return CommandLine.DurationP(name, shorthand, value, usage)
+}
+
+// Like Duration, but only accepts a shorthand letter that can be used after a single dash.
+func DurationS(shorthand string, value time.Duration, usage string) *time.Duration {
+	return CommandLine.DurationP("", shorthand, value, usage)
 }

--- a/float32.go
+++ b/float32.go
@@ -32,6 +32,11 @@ func (f *FlagSet) Float32VarP(p *float32, name, shorthand string, value float32,
 	f.VarP(newFloat32Value(value, p), name, shorthand, usage)
 }
 
+// Like Float32Var, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Float32VarS(p *float32, shorthand string, value float32, usage string) {
+	f.VarP(newFloat32Value(value, p), "", shorthand, usage)
+}
+
 // Float32Var defines a float32 flag with specified name, default value, and usage string.
 // The argument p points to a float32 variable in which to store the value of the flag.
 func Float32Var(p *float32, name string, value float32, usage string) {
@@ -41,6 +46,11 @@ func Float32Var(p *float32, name string, value float32, usage string) {
 // Like Float32Var, but accepts a shorthand letter that can be used after a single dash.
 func Float32VarP(p *float32, name, shorthand string, value float32, usage string) {
 	CommandLine.VarP(newFloat32Value(value, p), name, shorthand, usage)
+}
+
+// Like Float32Var, but only accepts a shorthand letter that can be used after a single dash.
+func Float32VarS(p *float32, shorthand string, value float32, usage string) {
+	CommandLine.VarP(newFloat32Value(value, p), "", shorthand, usage)
 }
 
 // Float32 defines a float32 flag with specified name, default value, and usage string.
@@ -58,6 +68,13 @@ func (f *FlagSet) Float32P(name, shorthand string, value float32, usage string) 
 	return p
 }
 
+// Like Float32, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Float32S(shorthand string, value float32, usage string) *float32 {
+	p := new(float32)
+	f.Float32VarP(p, "", shorthand, value, usage)
+	return p
+}
+
 // Float32 defines a float32 flag with specified name, default value, and usage string.
 // The return value is the address of a float32 variable that stores the value of the flag.
 func Float32(name string, value float32, usage string) *float32 {
@@ -67,4 +84,9 @@ func Float32(name string, value float32, usage string) *float32 {
 // Like Float32, but accepts a shorthand letter that can be used after a single dash.
 func Float32P(name, shorthand string, value float32, usage string) *float32 {
 	return CommandLine.Float32P(name, shorthand, value, usage)
+}
+
+// Like Float32, but only accepts a shorthand letter that can be used after a single dash.
+func Float32S(shorthand string, value float32, usage string) *float32 {
+	return CommandLine.Float32P("", shorthand, value, usage)
 }

--- a/float64.go
+++ b/float64.go
@@ -32,6 +32,11 @@ func (f *FlagSet) Float64VarP(p *float64, name, shorthand string, value float64,
 	f.VarP(newFloat64Value(value, p), name, shorthand, usage)
 }
 
+// Like Float64Var, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Float64VarS(p *float64, shorthand string, value float64, usage string) {
+	f.VarP(newFloat64Value(value, p), "", shorthand, usage)
+}
+
 // Float64Var defines a float64 flag with specified name, default value, and usage string.
 // The argument p points to a float64 variable in which to store the value of the flag.
 func Float64Var(p *float64, name string, value float64, usage string) {
@@ -41,6 +46,11 @@ func Float64Var(p *float64, name string, value float64, usage string) {
 // Like Float64Var, but accepts a shorthand letter that can be used after a single dash.
 func Float64VarP(p *float64, name, shorthand string, value float64, usage string) {
 	CommandLine.VarP(newFloat64Value(value, p), name, shorthand, usage)
+}
+
+// Like Float64Var, but only accepts a shorthand letter that can be used after a single dash.
+func Float64VarS(p *float64, shorthand string, value float64, usage string) {
+	CommandLine.VarP(newFloat64Value(value, p), "", shorthand, usage)
 }
 
 // Float64 defines a float64 flag with specified name, default value, and usage string.
@@ -58,6 +68,13 @@ func (f *FlagSet) Float64P(name, shorthand string, value float64, usage string) 
 	return p
 }
 
+// Like Float64, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Float64S(shorthand string, value float64, usage string) *float64 {
+	p := new(float64)
+	f.Float64VarP(p, "", shorthand, value, usage)
+	return p
+}
+
 // Float64 defines a float64 flag with specified name, default value, and usage string.
 // The return value is the address of a float64 variable that stores the value of the flag.
 func Float64(name string, value float64, usage string) *float64 {
@@ -67,4 +84,9 @@ func Float64(name string, value float64, usage string) *float64 {
 // Like Float64, but accepts a shorthand letter that can be used after a single dash.
 func Float64P(name, shorthand string, value float64, usage string) *float64 {
 	return CommandLine.Float64P(name, shorthand, value, usage)
+}
+
+// Like Float64, but only accepts a shorthand letter that can be used after a single dash.
+func Float64S(shorthand string, value float64, usage string) *float64 {
+	return CommandLine.Float64P("", shorthand, value, usage)
 }

--- a/int.go
+++ b/int.go
@@ -32,6 +32,11 @@ func (f *FlagSet) IntVarP(p *int, name, shorthand string, value int, usage strin
 	f.VarP(newIntValue(value, p), name, shorthand, usage)
 }
 
+// Like IntVar, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) IntVarS(p *int, shorthand string, value int, usage string) {
+	f.VarP(newIntValue(value, p), "", shorthand, usage)
+}
+
 // IntVar defines an int flag with specified name, default value, and usage string.
 // The argument p points to an int variable in which to store the value of the flag.
 func IntVar(p *int, name string, value int, usage string) {
@@ -41,6 +46,11 @@ func IntVar(p *int, name string, value int, usage string) {
 // Like IntVar, but accepts a shorthand letter that can be used after a single dash.
 func IntVarP(p *int, name, shorthand string, value int, usage string) {
 	CommandLine.VarP(newIntValue(value, p), name, shorthand, usage)
+}
+
+// Like IntVar, but only accepts a shorthand letter that can be used after a single dash.
+func IntVarS(p *int, shorthand string, value int, usage string) {
+	CommandLine.VarP(newIntValue(value, p), "", shorthand, usage)
 }
 
 // Int defines an int flag with specified name, default value, and usage string.
@@ -58,6 +68,13 @@ func (f *FlagSet) IntP(name, shorthand string, value int, usage string) *int {
 	return p
 }
 
+// Like Int, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) IntS(shorthand string, value int, usage string) *int {
+	p := new(int)
+	f.IntVarP(p, "", shorthand, value, usage)
+	return p
+}
+
 // Int defines an int flag with specified name, default value, and usage string.
 // The return value is the address of an int variable that stores the value of the flag.
 func Int(name string, value int, usage string) *int {
@@ -67,4 +84,9 @@ func Int(name string, value int, usage string) *int {
 // Like Int, but accepts a shorthand letter that can be used after a single dash.
 func IntP(name, shorthand string, value int, usage string) *int {
 	return CommandLine.IntP(name, shorthand, value, usage)
+}
+
+// Like Int, but only accepts a shorthand letter that can be used after a single dash.
+func IntS(shorthand string, value int, usage string) *int {
+	return CommandLine.IntP("", shorthand, value, usage)
 }

--- a/int32.go
+++ b/int32.go
@@ -32,6 +32,11 @@ func (f *FlagSet) Int32VarP(p *int32, name, shorthand string, value int32, usage
 	f.VarP(newInt32Value(value, p), name, shorthand, usage)
 }
 
+// Like Int32Var, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Int32VarS(p *int32, shorthand string, value int32, usage string) {
+	f.VarP(newInt32Value(value, p), "", shorthand, usage)
+}
+
 // Int32Var defines an int32 flag with specified name, default value, and usage string.
 // The argument p points to an int32 variable in which to store the value of the flag.
 func Int32Var(p *int32, name string, value int32, usage string) {
@@ -41,6 +46,11 @@ func Int32Var(p *int32, name string, value int32, usage string) {
 // Like Int32Var, but accepts a shorthand letter that can be used after a single dash.
 func Int32VarP(p *int32, name, shorthand string, value int32, usage string) {
 	CommandLine.VarP(newInt32Value(value, p), name, shorthand, usage)
+}
+
+// Like Int32Var, but only accepts a shorthand letter that can be used after a single dash.
+func Int32VarS(p *int32, shorthand string, value int32, usage string) {
+	CommandLine.VarP(newInt32Value(value, p), "", shorthand, usage)
 }
 
 // Int32 defines an int32 flag with specified name, default value, and usage string.
@@ -58,6 +68,13 @@ func (f *FlagSet) Int32P(name, shorthand string, value int32, usage string) *int
 	return p
 }
 
+// Like Int32, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Int32S(shorthand string, value int32, usage string) *int32 {
+	p := new(int32)
+	f.Int32VarP(p, "", shorthand, value, usage)
+	return p
+}
+
 // Int32 defines an int32 flag with specified name, default value, and usage string.
 // The return value is the address of an int32 variable that stores the value of the flag.
 func Int32(name string, value int32, usage string) *int32 {
@@ -67,4 +84,9 @@ func Int32(name string, value int32, usage string) *int32 {
 // Like Int32, but accepts a shorthand letter that can be used after a single dash.
 func Int32P(name, shorthand string, value int32, usage string) *int32 {
 	return CommandLine.Int32P(name, shorthand, value, usage)
+}
+
+// Like Int32, but only accepts a shorthand letter that can be used after a single dash.
+func Int32S(shorthand string, value int32, usage string) *int32 {
+	return CommandLine.Int32P("", shorthand, value, usage)
 }

--- a/int64.go
+++ b/int64.go
@@ -32,6 +32,11 @@ func (f *FlagSet) Int64VarP(p *int64, name, shorthand string, value int64, usage
 	f.VarP(newInt64Value(value, p), name, shorthand, usage)
 }
 
+// Like Int64Var, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Int64VarS(p *int64, shorthand string, value int64, usage string) {
+	f.VarP(newInt64Value(value, p), "", shorthand, usage)
+}
+
 // Int64Var defines an int64 flag with specified name, default value, and usage string.
 // The argument p points to an int64 variable in which to store the value of the flag.
 func Int64Var(p *int64, name string, value int64, usage string) {
@@ -41,6 +46,11 @@ func Int64Var(p *int64, name string, value int64, usage string) {
 // Like Int64Var, but accepts a shorthand letter that can be used after a single dash.
 func Int64VarP(p *int64, name, shorthand string, value int64, usage string) {
 	CommandLine.VarP(newInt64Value(value, p), name, shorthand, usage)
+}
+
+// Like Int64Var, but only accepts a shorthand letter that can be used after a single dash.
+func Int64VarS(p *int64, shorthand string, value int64, usage string) {
+	CommandLine.VarP(newInt64Value(value, p), "", shorthand, usage)
 }
 
 // Int64 defines an int64 flag with specified name, default value, and usage string.
@@ -58,6 +68,13 @@ func (f *FlagSet) Int64P(name, shorthand string, value int64, usage string) *int
 	return p
 }
 
+// Like Int64, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Int64S(shorthand string, value int64, usage string) *int64 {
+	p := new(int64)
+	f.Int64VarP(p, "", shorthand, value, usage)
+	return p
+}
+
 // Int64 defines an int64 flag with specified name, default value, and usage string.
 // The return value is the address of an int64 variable that stores the value of the flag.
 func Int64(name string, value int64, usage string) *int64 {
@@ -67,4 +84,9 @@ func Int64(name string, value int64, usage string) *int64 {
 // Like Int64, but accepts a shorthand letter that can be used after a single dash.
 func Int64P(name, shorthand string, value int64, usage string) *int64 {
 	return CommandLine.Int64P(name, shorthand, value, usage)
+}
+
+// Like Int64, but only accepts a shorthand letter that can be used after a single dash.
+func Int64S(shorthand string, value int64, usage string) *int64 {
+	return CommandLine.Int64P("", shorthand, value, usage)
 }

--- a/int8.go
+++ b/int8.go
@@ -32,6 +32,11 @@ func (f *FlagSet) Int8VarP(p *int8, name, shorthand string, value int8, usage st
 	f.VarP(newInt8Value(value, p), name, shorthand, usage)
 }
 
+// Like Int8Var, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Int8VarS(p *int8, shorthand string, value int8, usage string) {
+	f.VarP(newInt8Value(value, p), "", shorthand, usage)
+}
+
 // Int8Var defines an int8 flag with specified name, default value, and usage string.
 // The argument p points to an int8 variable in which to store the value of the flag.
 func Int8Var(p *int8, name string, value int8, usage string) {
@@ -41,6 +46,11 @@ func Int8Var(p *int8, name string, value int8, usage string) {
 // Like Int8Var, but accepts a shorthand letter that can be used after a single dash.
 func Int8VarP(p *int8, name, shorthand string, value int8, usage string) {
 	CommandLine.VarP(newInt8Value(value, p), name, shorthand, usage)
+}
+
+// Like Int8Var, but only accepts a shorthand letter that can be used after a single dash.
+func Int8VarS(p *int8, shorthand string, value int8, usage string) {
+	CommandLine.VarP(newInt8Value(value, p), "", shorthand, usage)
 }
 
 // Int8 defines an int8 flag with specified name, default value, and usage string.
@@ -58,6 +68,13 @@ func (f *FlagSet) Int8P(name, shorthand string, value int8, usage string) *int8 
 	return p
 }
 
+// Like Int8, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Int8S(shorthand string, value int8, usage string) *int8 {
+	p := new(int8)
+	f.Int8VarP(p, "", shorthand, value, usage)
+	return p
+}
+
 // Int8 defines an int8 flag with specified name, default value, and usage string.
 // The return value is the address of an int8 variable that stores the value of the flag.
 func Int8(name string, value int8, usage string) *int8 {
@@ -67,4 +84,9 @@ func Int8(name string, value int8, usage string) *int8 {
 // Like Int8, but accepts a shorthand letter that can be used after a single dash.
 func Int8P(name, shorthand string, value int8, usage string) *int8 {
 	return CommandLine.Int8P(name, shorthand, value, usage)
+}
+
+// Like Int8, but only accepts a shorthand letter that can be used after a single dash.
+func Int8S(shorthand string, value int8, usage string) *int8 {
+	return CommandLine.Int8P("", shorthand, value, usage)
 }

--- a/ip.go
+++ b/ip.go
@@ -37,6 +37,11 @@ func (f *FlagSet) IPVarP(p *net.IP, name, shorthand string, value net.IP, usage 
 	f.VarP(newIPValue(value, p), name, shorthand, usage)
 }
 
+// Like IPVar, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) IPVarS(p *net.IP, shorthand string, value net.IP, usage string) {
+	f.VarP(newIPValue(value, p), "", shorthand, usage)
+}
+
 // IPVar defines an net.IP flag with specified name, default value, and usage string.
 // The argument p points to an net.IP variable in which to store the value of the flag.
 func IPVar(p *net.IP, name string, value net.IP, usage string) {
@@ -46,6 +51,11 @@ func IPVar(p *net.IP, name string, value net.IP, usage string) {
 // Like IPVar, but accepts a shorthand letter that can be used after a single dash.
 func IPVarP(p *net.IP, name, shorthand string, value net.IP, usage string) {
 	CommandLine.VarP(newIPValue(value, p), name, shorthand, usage)
+}
+
+// Like IPVar, but only accepts a shorthand letter that can be used after a single dash.
+func IPVarS(p *net.IP, shorthand string, value net.IP, usage string) {
+	CommandLine.VarP(newIPValue(value, p), "", shorthand, usage)
 }
 
 // IP defines an net.IP flag with specified name, default value, and usage string.
@@ -63,6 +73,13 @@ func (f *FlagSet) IPP(name, shorthand string, value net.IP, usage string) *net.I
 	return p
 }
 
+// Like IP, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) IPS(shorthand string, value net.IP, usage string) *net.IP {
+	p := new(net.IP)
+	f.IPVarP(p, "", shorthand, value, usage)
+	return p
+}
+
 // IP defines an net.IP flag with specified name, default value, and usage string.
 // The return value is the address of an net.IP variable that stores the value of the flag.
 func IP(name string, value net.IP, usage string) *net.IP {
@@ -72,4 +89,9 @@ func IP(name string, value net.IP, usage string) *net.IP {
 // Like IP, but accepts a shorthand letter that can be used after a single dash.
 func IPP(name, shorthand string, value net.IP, usage string) *net.IP {
 	return CommandLine.IPP(name, shorthand, value, usage)
+}
+
+// Like IP, but only accepts a shorthand letter that can be used after a single dash.
+func IPS(shorthand string, value net.IP, usage string) *net.IP {
+	return CommandLine.IPP("", shorthand, value, usage)
 }

--- a/ipmask.go
+++ b/ipmask.go
@@ -47,6 +47,11 @@ func (f *FlagSet) IPMaskVarP(p *net.IPMask, name, shorthand string, value net.IP
 	f.VarP(newIPMaskValue(value, p), name, shorthand, usage)
 }
 
+// Like IPMaskVar, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) IPMaskVarS(p *net.IPMask, shorthand string, value net.IPMask, usage string) {
+	f.VarP(newIPMaskValue(value, p), "", shorthand, usage)
+}
+
 // IPMaskVar defines an net.IPMask flag with specified name, default value, and usage string.
 // The argument p points to an net.IPMask variable in which to store the value of the flag.
 func IPMaskVar(p *net.IPMask, name string, value net.IPMask, usage string) {
@@ -56,6 +61,11 @@ func IPMaskVar(p *net.IPMask, name string, value net.IPMask, usage string) {
 // Like IPMaskVar, but accepts a shorthand letter that can be used after a single dash.
 func IPMaskVarP(p *net.IPMask, name, shorthand string, value net.IPMask, usage string) {
 	CommandLine.VarP(newIPMaskValue(value, p), name, shorthand, usage)
+}
+
+// Like IPMaskVar, but only accepts a shorthand letter that can be used after a single dash.
+func IPMaskVarS(p *net.IPMask, shorthand string, value net.IPMask, usage string) {
+	CommandLine.VarP(newIPMaskValue(value, p), "", shorthand, usage)
 }
 
 // IPMask defines an net.IPMask flag with specified name, default value, and usage string.
@@ -73,6 +83,13 @@ func (f *FlagSet) IPMaskP(name, shorthand string, value net.IPMask, usage string
 	return p
 }
 
+// Like IPMask, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) IPMaskS(shorthand string, value net.IPMask, usage string) *net.IPMask {
+	p := new(net.IPMask)
+	f.IPMaskVarP(p, "", shorthand, value, usage)
+	return p
+}
+
 // IPMask defines an net.IPMask flag with specified name, default value, and usage string.
 // The return value is the address of an net.IPMask variable that stores the value of the flag.
 func IPMask(name string, value net.IPMask, usage string) *net.IPMask {
@@ -82,4 +99,9 @@ func IPMask(name string, value net.IPMask, usage string) *net.IPMask {
 // Like IP, but accepts a shorthand letter that can be used after a single dash.
 func IPMaskP(name, shorthand string, value net.IPMask, usage string) *net.IPMask {
 	return CommandLine.IPMaskP(name, shorthand, value, usage)
+}
+
+// Like IP, but only accepts a shorthand letter that can be used after a single dash.
+func IPMaskS(shorthand string, value net.IPMask, usage string) *net.IPMask {
+	return CommandLine.IPMaskP("", shorthand, value, usage)
 }

--- a/string.go
+++ b/string.go
@@ -28,6 +28,11 @@ func (f *FlagSet) StringVarP(p *string, name, shorthand string, value string, us
 	f.VarP(newStringValue(value, p), name, shorthand, usage)
 }
 
+// Like StringVar, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) StringVarS(p *string, shorthand string, value string, usage string) {
+	f.VarP(newStringValue(value, p), "", shorthand, usage)
+}
+
 // StringVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a string variable in which to store the value of the flag.
 func StringVar(p *string, name string, value string, usage string) {
@@ -37,6 +42,11 @@ func StringVar(p *string, name string, value string, usage string) {
 // Like StringVar, but accepts a shorthand letter that can be used after a single dash.
 func StringVarP(p *string, name, shorthand string, value string, usage string) {
 	CommandLine.VarP(newStringValue(value, p), name, shorthand, usage)
+}
+
+// Like StringVar, but only accepts a shorthand letter that can be used after a single dash.
+func StringVarS(p *string, shorthand string, value string, usage string) {
+	CommandLine.VarP(newStringValue(value, p), "", shorthand, usage)
 }
 
 // String defines a string flag with specified name, default value, and usage string.
@@ -54,6 +64,13 @@ func (f *FlagSet) StringP(name, shorthand string, value string, usage string) *s
 	return p
 }
 
+// Like String, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) StringS(shorthand string, value string, usage string) *string {
+	p := new(string)
+	f.StringVarP(p, "", shorthand, value, usage)
+	return p
+}
+
 // String defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a string variable that stores the value of the flag.
 func String(name string, value string, usage string) *string {
@@ -63,4 +80,9 @@ func String(name string, value string, usage string) *string {
 // Like String, but accepts a shorthand letter that can be used after a single dash.
 func StringP(name, shorthand string, value string, usage string) *string {
 	return CommandLine.StringP(name, shorthand, value, usage)
+}
+
+// Like String, but only accepts a shorthand letter that can be used after a single dash.
+func StringS(shorthand string, value string, usage string) *string {
+	return CommandLine.StringP("", shorthand, value, usage)
 }

--- a/uint.go
+++ b/uint.go
@@ -32,6 +32,11 @@ func (f *FlagSet) UintVarP(p *uint, name, shorthand string, value uint, usage st
 	f.VarP(newUintValue(value, p), name, shorthand, usage)
 }
 
+// Like UintVar, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) UintVarS(p *uint, shorthand string, value uint, usage string) {
+	f.VarP(newUintValue(value, p), "", shorthand, usage)
+}
+
 // UintVar defines a uint flag with specified name, default value, and usage string.
 // The argument p points to a uint  variable in which to store the value of the flag.
 func UintVar(p *uint, name string, value uint, usage string) {
@@ -41,6 +46,11 @@ func UintVar(p *uint, name string, value uint, usage string) {
 // Like UintVar, but accepts a shorthand letter that can be used after a single dash.
 func UintVarP(p *uint, name, shorthand string, value uint, usage string) {
 	CommandLine.VarP(newUintValue(value, p), name, shorthand, usage)
+}
+
+// Like UintVar, but only accepts a shorthand letter that can be used after a single dash.
+func UintVarS(p *uint, shorthand string, value uint, usage string) {
+	CommandLine.VarP(newUintValue(value, p), "", shorthand, usage)
 }
 
 // Uint defines a uint flag with specified name, default value, and usage string.
@@ -58,6 +68,13 @@ func (f *FlagSet) UintP(name, shorthand string, value uint, usage string) *uint 
 	return p
 }
 
+// Like Uint, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) UintS(shorthand string, value uint, usage string) *uint {
+	p := new(uint)
+	f.UintVarP(p, "", shorthand, value, usage)
+	return p
+}
+
 // Uint defines a uint flag with specified name, default value, and usage string.
 // The return value is the address of a uint  variable that stores the value of the flag.
 func Uint(name string, value uint, usage string) *uint {
@@ -67,4 +84,9 @@ func Uint(name string, value uint, usage string) *uint {
 // Like Uint, but accepts a shorthand letter that can be used after a single dash.
 func UintP(name, shorthand string, value uint, usage string) *uint {
 	return CommandLine.UintP(name, shorthand, value, usage)
+}
+
+// Like Uint, but only accepts a shorthand letter that can be used after a single dash.
+func UintS(shorthand string, value uint, usage string) *uint {
+	return CommandLine.UintP("", shorthand, value, usage)
 }

--- a/uint16.go
+++ b/uint16.go
@@ -33,6 +33,11 @@ func (f *FlagSet) Uint16VarP(p *uint16, name, shorthand string, value uint16, us
 	f.VarP(newUint16Value(value, p), name, shorthand, usage)
 }
 
+// Like Uint16Var, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Uint16VarS(p *uint16, shorthand string, value uint16, usage string) {
+	f.VarP(newUint16Value(value, p), "", shorthand, usage)
+}
+
 // Uint16Var defines a uint flag with specified name, default value, and usage string.
 // The argument p points to a uint  variable in which to store the value of the flag.
 func Uint16Var(p *uint16, name string, value uint16, usage string) {
@@ -42,6 +47,11 @@ func Uint16Var(p *uint16, name string, value uint16, usage string) {
 // Like Uint16Var, but accepts a shorthand letter that can be used after a single dash.
 func Uint16VarP(p *uint16, name, shorthand string, value uint16, usage string) {
 	CommandLine.VarP(newUint16Value(value, p), name, shorthand, usage)
+}
+
+// Like Uint16Var, but only accepts a shorthand letter that can be used after a single dash.
+func Uint16Vars(p *uint16, shorthand string, value uint16, usage string) {
+	CommandLine.VarP(newUint16Value(value, p), "", shorthand, usage)
 }
 
 // Uint16 defines a uint flag with specified name, default value, and usage string.
@@ -59,6 +69,13 @@ func (f *FlagSet) Uint16P(name, shorthand string, value uint16, usage string) *u
 	return p
 }
 
+// Like Uint16, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Uint16S(shorthand string, value uint16, usage string) *uint16 {
+	p := new(uint16)
+	f.Uint16VarP(p, "", shorthand, value, usage)
+	return p
+}
+
 // Uint16 defines a uint flag with specified name, default value, and usage string.
 // The return value is the address of a uint  variable that stores the value of the flag.
 func Uint16(name string, value uint16, usage string) *uint16 {
@@ -68,4 +85,9 @@ func Uint16(name string, value uint16, usage string) *uint16 {
 // Like Uint16, but accepts a shorthand letter that can be used after a single dash.
 func Uint16P(name, shorthand string, value uint16, usage string) *uint16 {
 	return CommandLine.Uint16P(name, shorthand, value, usage)
+}
+
+// Like Uint16, but only accepts a shorthand letter that can be used after a single dash.
+func Uint16S(shorthand string, value uint16, usage string) *uint16 {
+	return CommandLine.Uint16P("", shorthand, value, usage)
 }

--- a/uint32.go
+++ b/uint32.go
@@ -33,6 +33,11 @@ func (f *FlagSet) Uint32VarP(p *uint32, name, shorthand string, value uint32, us
 	f.VarP(newUint32Value(value, p), name, shorthand, usage)
 }
 
+// Like Uint32Var, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Uint32VarS(p *uint32, shorthand string, value uint32, usage string) {
+	f.VarP(newUint32Value(value, p), "", shorthand, usage)
+}
+
 // Uint32Var defines a uint32 flag with specified name, default value, and usage string.
 // The argument p points to a uint32  variable in which to store the value of the flag.
 func Uint32Var(p *uint32, name string, value uint32, usage string) {
@@ -42,6 +47,11 @@ func Uint32Var(p *uint32, name string, value uint32, usage string) {
 // Like Uint32Var, but accepts a shorthand letter that can be used after a single dash.
 func Uint32VarP(p *uint32, name, shorthand string, value uint32, usage string) {
 	CommandLine.VarP(newUint32Value(value, p), name, shorthand, usage)
+}
+
+// Like Uint32Var, but only accepts a shorthand letter that can be used after a single dash.
+func Uint32VarS(p *uint32, shorthand string, value uint32, usage string) {
+	CommandLine.VarP(newUint32Value(value, p), "", shorthand, usage)
 }
 
 // Uint32 defines a uint32 flag with specified name, default value, and usage string.
@@ -59,6 +69,13 @@ func (f *FlagSet) Uint32P(name, shorthand string, value uint32, usage string) *u
 	return p
 }
 
+// Like Uint32, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Uint32S(shorthand string, value uint32, usage string) *uint32 {
+	p := new(uint32)
+	f.Uint32VarP(p, "", shorthand, value, usage)
+	return p
+}
+
 // Uint32 defines a uint32 flag with specified name, default value, and usage string.
 // The return value is the address of a uint32  variable that stores the value of the flag.
 func Uint32(name string, value uint32, usage string) *uint32 {
@@ -68,4 +85,9 @@ func Uint32(name string, value uint32, usage string) *uint32 {
 // Like Uint32, but accepts a shorthand letter that can be used after a single dash.
 func Uint32P(name, shorthand string, value uint32, usage string) *uint32 {
 	return CommandLine.Uint32P(name, shorthand, value, usage)
+}
+
+// Like Uint32, but only accepts a shorthand letter that can be used after a single dash.
+func Uint32S(shorthand string, value uint32, usage string) *uint32 {
+	return CommandLine.Uint32P("", shorthand, value, usage)
 }

--- a/uint64.go
+++ b/uint64.go
@@ -32,6 +32,11 @@ func (f *FlagSet) Uint64VarP(p *uint64, name, shorthand string, value uint64, us
 	f.VarP(newUint64Value(value, p), name, shorthand, usage)
 }
 
+// Like Uint64Var, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Uint64VarS(p *uint64, shorthand string, value uint64, usage string) {
+	f.VarP(newUint64Value(value, p), "", shorthand, usage)
+}
+
 // Uint64Var defines a uint64 flag with specified name, default value, and usage string.
 // The argument p points to a uint64 variable in which to store the value of the flag.
 func Uint64Var(p *uint64, name string, value uint64, usage string) {
@@ -41,6 +46,11 @@ func Uint64Var(p *uint64, name string, value uint64, usage string) {
 // Like Uint64Var, but accepts a shorthand letter that can be used after a single dash.
 func Uint64VarP(p *uint64, name, shorthand string, value uint64, usage string) {
 	CommandLine.VarP(newUint64Value(value, p), name, shorthand, usage)
+}
+
+// Like Uint64Var, but only accepts a shorthand letter that can be used after a single dash.
+func Uint64VarS(p *uint64, shorthand string, value uint64, usage string) {
+	CommandLine.VarP(newUint64Value(value, p), "", shorthand, usage)
 }
 
 // Uint64 defines a uint64 flag with specified name, default value, and usage string.
@@ -58,6 +68,13 @@ func (f *FlagSet) Uint64P(name, shorthand string, value uint64, usage string) *u
 	return p
 }
 
+// Like Uint64, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Uint64S(shorthand string, value uint64, usage string) *uint64 {
+	p := new(uint64)
+	f.Uint64VarP(p, "", shorthand, value, usage)
+	return p
+}
+
 // Uint64 defines a uint64 flag with specified name, default value, and usage string.
 // The return value is the address of a uint64 variable that stores the value of the flag.
 func Uint64(name string, value uint64, usage string) *uint64 {
@@ -67,4 +84,9 @@ func Uint64(name string, value uint64, usage string) *uint64 {
 // Like Uint64, but accepts a shorthand letter that can be used after a single dash.
 func Uint64P(name, shorthand string, value uint64, usage string) *uint64 {
 	return CommandLine.Uint64P(name, shorthand, value, usage)
+}
+
+// Like Uint64, but only accepts a shorthand letter that can be used after a single dash.
+func Uint64S(shorthand string, value uint64, usage string) *uint64 {
+	return CommandLine.Uint64P("", shorthand, value, usage)
 }

--- a/uint8.go
+++ b/uint8.go
@@ -32,6 +32,11 @@ func (f *FlagSet) Uint8VarP(p *uint8, name, shorthand string, value uint8, usage
 	f.VarP(newUint8Value(value, p), name, shorthand, usage)
 }
 
+// Like Uint8Var, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Uint8VarS(p *uint8, shorthand string, value uint8, usage string) {
+	f.VarP(newUint8Value(value, p), "", shorthand, usage)
+}
+
 // Uint8Var defines a uint8 flag with specified name, default value, and usage string.
 // The argument p points to a uint8 variable in which to store the value of the flag.
 func Uint8Var(p *uint8, name string, value uint8, usage string) {
@@ -41,6 +46,11 @@ func Uint8Var(p *uint8, name string, value uint8, usage string) {
 // Like Uint8Var, but accepts a shorthand letter that can be used after a single dash.
 func Uint8VarP(p *uint8, name, shorthand string, value uint8, usage string) {
 	CommandLine.VarP(newUint8Value(value, p), name, shorthand, usage)
+}
+
+// Like Uint8Var, but only accepts a shorthand letter that can be used after a single dash.
+func Uint8VarS(p *uint8, shorthand string, value uint8, usage string) {
+	CommandLine.VarP(newUint8Value(value, p), "", shorthand, usage)
 }
 
 // Uint8 defines a uint8 flag with specified name, default value, and usage string.
@@ -58,6 +68,13 @@ func (f *FlagSet) Uint8P(name, shorthand string, value uint8, usage string) *uin
 	return p
 }
 
+// Like Uint8, but only accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) Uint8S(shorthand string, value uint8, usage string) *uint8 {
+	p := new(uint8)
+	f.Uint8VarP(p, "", shorthand, value, usage)
+	return p
+}
+
 // Uint8 defines a uint8 flag with specified name, default value, and usage string.
 // The return value is the address of a uint8 variable that stores the value of the flag.
 func Uint8(name string, value uint8, usage string) *uint8 {
@@ -67,4 +84,9 @@ func Uint8(name string, value uint8, usage string) *uint8 {
 // Like Uint8, but accepts a shorthand letter that can be used after a single dash.
 func Uint8P(name, shorthand string, value uint8, usage string) *uint8 {
 	return CommandLine.Uint8P(name, shorthand, value, usage)
+}
+
+// Like Uint8, but only accepts a shorthand letter that can be used after a single dash.
+func Uint8s(shorthand string, value uint8, usage string) *uint8 {
+	return CommandLine.Uint8P("", shorthand, value, usage)
 }


### PR DESCRIPTION
I wanted flags that can only be specified as `-f` and not `--f`. Mainly because it allows for the help to look better.
I think this type of flag is mostly useful for bool flags, but I added convenience methods/functions for all flag types by adding `S` to the name: `BoolS`.
For `BoolS("f", false, "blah")` the help is: `      -f=false: blah`.